### PR TITLE
Check for the log directory

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -106,6 +106,18 @@ fi
 
 [ "$justconfig" = "1" ] && echo "Just configuring - exit" && exit 0
 
+# Logs
+#
+if [ "$logging" != "stdout" && "$logging" != "stderr" && \
+		"${logging%%:*}" != "syslog" ]; then
+	mkdir -p `dirname $logging`
+fi
+
+mkdir -p `dirname $bakerlogging`
+mkdir -p `dirname $accuselogging`
+mkdir -p `dirname $endorselogging`
+
+
 # Let's go then
 #
 echo "===> Starting $name node"

--- a/start.sh
+++ b/start.sh
@@ -8,6 +8,10 @@
 #
 bake=0
 logging=stdout
+bakerlogging=$HOME/logs/logfile_baking
+accuselogging=$HOME/logs/logfile_accuser
+endorselogging=$HOME/logs/logfile_endorser
+
 background=0
 dontconfig=0
 justconfig=0
@@ -73,6 +77,7 @@ if [ ! -d "$datadir" ] || [ ! -f "$datadir/config.json" ]; then
 	# Sometimes we will want to setup a node manually
 	#
 	[ "$dontconfig" = "1" ] && echo "Skipping configuration!" && exit 1
+
 
 	echo "===> Setting up configuration"
 	mkdir -p "$datadir"

--- a/start.sh
+++ b/start.sh
@@ -108,8 +108,8 @@ fi
 
 # Logs
 #
-if [ "$logging" != "stdout" && "$logging" != "stderr" && \
-		"${logging%%:*}" != "syslog" ]; then
+if [ "$logging" != "stdout" ] && [ "$logging" != "stderr" ] && \
+		[ "${logging%%:*}" != "syslog" ]; then
 	mkdir -p `dirname $logging`
 fi
 


### PR DESCRIPTION
On startup, Tezos-node will fail if the path to the log file cannot be written. Check that we are writing to a log file and if we are make sure its directory exists. Repeat for the baking logs.